### PR TITLE
return [] instead of null when no resources are found

### DIFF
--- a/list_response.go
+++ b/list_response.go
@@ -35,6 +35,10 @@ type listResponse struct {
 }
 
 func (l listResponse) MarshalJSON() ([]byte, error) {
+	// Allows json.Marshall to return [] instead of null
+	if len(l.Resources) < 1 {
+		l.Resources = make([]interface{}, 0)
+	}
 	return json.Marshal(map[string]interface{}{
 		"schemas":      []string{"urn:ietf:params:scim:api:messages:2.0:ListResponse"},
 		"totalResults": l.TotalResults,


### PR DESCRIPTION
Return an empty array instead of "null" for IDPs, like Azure, that may require this.